### PR TITLE
remove trailing whitespace and unimplemented closeSubscriptions() function

### DIFF
--- a/include/nostr.hpp
+++ b/include/nostr.hpp
@@ -164,7 +164,7 @@ public:
      * @brief Closes any open connections to the specified Nostr relays.
      */
     void closeRelayConnections(std::vector<std::string> relays);
-    
+
     /**
      * @brief Publishes a Nostr event to all open relay connections.
      * @returns A tuple of `std::vector<std::string>` objects, of the form `<successes, failures>`, indicating
@@ -206,7 +206,7 @@ public:
         std::function<void(const std::string&, std::shared_ptr<Event>)> eventHandler,
         std::function<void(const std::string&)> eoseHandler,
         std::function<void(const std::string&, const std::string&)> closeHandler);
-    
+
     /**
      * @brief Closes the subscription with the given ID on all open relay connections.
      * @returns A tuple of `std::vector<std::string>` objects, of the form `<successes, failures>`, indicating
@@ -229,12 +229,6 @@ public:
      */
     std::vector<std::string> closeSubscriptions();
 
-    /**
-     * @brief Closes all open subscriptions on the given relays.
-     * @returns A list of any subscription IDs that failed to close.
-     */
-    std::vector<std::string> closeSubscriptions(std::vector<std::string> relays);
-
 private:
     ///< The maximum number of events the service will store for each subscription.
     const int MAX_EVENTS_PER_SUBSCRIPTION = 128;
@@ -249,7 +243,7 @@ private:
     ///< The default set of Nostr relays to which the service will attempt to connect.
     std::vector<std::string> _defaultRelays;
     ///< The set of Nostr relays to which the service is currently connected.
-    std::vector<std::string> _activeRelays; 
+    std::vector<std::string> _activeRelays;
     ///< A map from subscription IDs to the relays on which each subscription is open.
     std::unordered_map<std::string, std::vector<std::string>> _subscriptions;
 
@@ -327,7 +321,7 @@ private:
         std::function<void(const std::string&, std::shared_ptr<Event>)> eventHandler,
         std::function<void(const std::string&)> eoseHandler,
         std::function<void(const std::string&, const std::string&)> closeHandler);
-    
+
     /**
      * @brief Parses OK messages received from the relay and invokes the given acceptance handler.
      * @remark The OK message type is sent to indicate whether the relay has accepted an event sent

--- a/src/client/websocketpp_client.cpp
+++ b/src/client/websocketpp_client.cpp
@@ -18,7 +18,7 @@ class WebsocketppClient : public IWebSocketClient
 {
 public:
     void start() override
-    { 
+    {
         this->_client.init_asio();
         this->_client.start_perpetual();
     };
@@ -34,7 +34,7 @@ public:
         error_code error;
         websocketpp_client::connection_ptr connection = this->_client.get_connection(uri, error);
 
-        if (error.value() == -1)    
+        if (error.value() == -1)
         {
             // PLOG_ERROR << "Error connecting to relay " << relay << ": " << error.message();
         }
@@ -72,7 +72,7 @@ public:
             websocketpp::frame::opcode::text,
             error);
 
-        if (error.value() == -1)    
+        if (error.value() == -1)
         {
             return make_tuple(uri, false);
         }
@@ -110,7 +110,7 @@ public:
             handle,
             websocketpp::close::status::going_away,
             "_client requested close.");
-        
+
         this->_connectionHandles.erase(uri);
     };
 

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -10,7 +10,7 @@ string Filters::serialize(string& subscriptionId)
     try
     {
         this->validate();
-    } 
+    }
     catch (const invalid_argument& e)
     {
         throw e;

--- a/src/nostr_service.cpp
+++ b/src/nostr_service.cpp
@@ -350,13 +350,13 @@ tuple<vector<string>, vector<string>> NostrService::closeSubscription(string sub
         PLOG_WARNING << "Subscription " << subscriptionId << " not found.";
         return make_tuple(successfulRelays, failedRelays);
     }
-    
+
     for (const string relay : subscriptionRelays)
     {
         future<tuple<string, bool>> closeFuture = async([this, subscriptionId, relay]()
         {
             bool success = this->closeSubscription(subscriptionId, relay);
-            
+
             return make_tuple(relay, success);
         });
         closeFutures.push_back(move(closeFuture));

--- a/test/nostr_service_test.cpp
+++ b/test/nostr_service_test.cpp
@@ -29,7 +29,7 @@ public:
     MOCK_METHOD(void, closeConnection, (string uri), (override));
 };
 
-class FakeSigner : public nostr::ISigner 
+class FakeSigner : public nostr::ISigner
 {
 public:
     void sign(shared_ptr<nostr::Event> event) override
@@ -71,7 +71,7 @@ public:
         nostr::Event event1;
         event1.pubkey = "13tn5ccv2guflxgffq4aj0hw5x39pz70zcdrfd6vym887gry38zys28dask";
         event1.kind = 1;
-        event1.tags = 
+        event1.tags =
         {
             { "e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://nostr.example.com" },
             { "p", "f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca" },
@@ -91,7 +91,7 @@ public:
         };
         event2.content = "Welcome to Nostr!";
         event2.createdAt = currentTime;
-        
+
         nostr::Event event3;
         event3.pubkey = "187ujhtmnv82ftg03h4heetwk3dd9mlfkf8th3fvmrk20nxk9mansuzuyla";
         event3.kind = 1;
@@ -124,7 +124,7 @@ public:
     }
 
     static const string getTestEventMessage(shared_ptr<nostr::Event> event, string subscriptionId)
-    {        
+    {
         auto signer = make_unique<FakeSigner>();
         signer->sign(event);
 
@@ -140,7 +140,7 @@ public:
     {
         nostr::Filters filters;
         filters.authors = {
-            "13tn5ccv2guflxgffq4aj0hw5x39pz70zcdrfd6vym887gry38zys28dask", 
+            "13tn5ccv2guflxgffq4aj0hw5x39pz70zcdrfd6vym887gry38zys28dask",
             "1l9d9jh67rkwayalrxcy686aujyz5pper5kzjv8jvg8pu9v9ns4ls0xvq42",
             "187ujhtmnv82ftg03h4heetwk3dd9mlfkf8th3fvmrk20nxk9mansuzuyla"
         };
@@ -154,7 +154,7 @@ public:
     {
         nostr::Filters filters;
         filters.authors = {
-            "13tn5ccv2guflxgffq4aj0hw5x39pz70zcdrfd6vym887gry38zys28dask", 
+            "13tn5ccv2guflxgffq4aj0hw5x39pz70zcdrfd6vym887gry38zys28dask",
             "1l9d9jh67rkwayalrxcy686aujyz5pper5kzjv8jvg8pu9v9ns4ls0xvq42",
             "187ujhtmnv82ftg03h4heetwk3dd9mlfkf8th3fvmrk20nxk9mansuzuyla"
         };
@@ -240,7 +240,7 @@ TEST_F(NostrServiceTest, OpenRelayConnections_OpensConnections_ToDefaultRelays)
             }
             return status;
         }));
-    
+
     auto nostrService = make_unique<nostr::NostrService>(
         testAppender,
         mockClient,
@@ -468,7 +468,7 @@ TEST_F(NostrServiceTest, PublishEvent_CorrectlyIndicates_AllSuccesses)
 
             return make_tuple(uri, true);
         }));
-    
+
     auto testEvent = make_shared<nostr::Event>(getTextNoteTestEvent());
     auto [successes, failures] = nostrService->publishEvent(testEvent);
 
@@ -514,7 +514,7 @@ TEST_F(NostrServiceTest, PublishEvent_CorrectlyIndicates_AllFailures)
         {
             return make_tuple(uri, false);
         }));
-    
+
     auto testEvent = make_shared<nostr::Event>(getTextNoteTestEvent());
     auto [successes, failures] = nostrService->publishEvent(testEvent);
 
@@ -573,7 +573,7 @@ TEST_F(NostrServiceTest, PublishEvent_CorrectlyIndicates_MixedSuccessesAndFailur
 
             return make_tuple(uri, true);
         }));
-    
+
     auto testEvent = make_shared<nostr::Event>(getTextNoteTestEvent());
     auto [successes, failures] = nostrService->publishEvent(testEvent);
 
@@ -623,7 +623,7 @@ TEST_F(NostrServiceTest, PublishEvent_CorrectlyIndicates_RejectedEvent)
 
             return make_tuple(uri, true);
         }));
-    
+
     auto testEvent = make_shared<nostr::Event>(getTextNoteTestEvent());
     auto [successes, failures] = nostrService->publishEvent(testEvent);
 
@@ -686,7 +686,7 @@ TEST_F(NostrServiceTest, PublishEvent_CorrectlyIndicates_EventRejectedBySomeRela
 
             return make_tuple(uri, true);
         }));
-    
+
     auto testEvent = make_shared<nostr::Event>(getTextNoteTestEvent());
     auto [successes, failures] = nostrService->publishEvent(testEvent);
 
@@ -890,7 +890,7 @@ TEST_F(NostrServiceTest, QueryRelays_CallsHandler_WithReturnedEvents)
             }
         },
         [](const string&, const string&) {});
-    
+
     eoseReceivedFuture.wait();
 
     // Check that the service is keeping track of its active subscriptions.
@@ -1055,7 +1055,7 @@ TEST_F(NostrServiceTest, Service_MaintainsMultipleSubscriptions_ThenClosesAll)
             longFormPromise.set_value();
         },
         [](const string&, const string&) {});
-    
+
     shortFormFuture.wait();
     longFormFuture.wait();
 


### PR DESCRIPTION
the function
`std::vector<std::string> closeSubscriptions(std::vector<std::string> relays)`
remains unimplemented, and I was bored at work, so I thought of implementing it, but then I saw that there isn't really any good use to it, so I removed it.

If I'm mistaken, please correct me @buttercat1791 