### PR TITLE
Resolution to issue 9

### DIFF
--- a/include/nostr.hpp
+++ b/include/nostr.hpp
@@ -177,7 +177,8 @@ public:
      * @brief Queries all open relay connections for events matching the given set of filters, and
      * returns all stored matching events returned by the relays.
      * @param filters The filters to use for the query.
-     * @returns A vector of all events matching the filters from all open relay connections.
+     * @returns A std::future that will eventually hold a vector of all events matching the filters
+     * from all open relay connections.
      * @remark This method runs until the relays send an EOSE message, indicating they have no more
      * stored events matching the given filters.  When the EOSE message is received, the method
      * will close the subscription for each relay and return the received events.
@@ -185,7 +186,7 @@ public:
      * set on the filters in the range 1-64, inclusive.  If no valid limit is given, it will be
      * defaulted to 16.
      */
-    std::vector<std::shared_ptr<Event>> queryRelays(std::shared_ptr<Filters> filters);
+    std::future<std::vector<std::shared_ptr<Event>>> queryRelays(std::shared_ptr<Filters> filters);
 
     /**
      * @brief Queries all open relay connections for events matching the given set of filters.

--- a/src/nostr_service.cpp
+++ b/src/nostr_service.cpp
@@ -183,9 +183,9 @@ tuple<vector<string>, vector<string>> NostrService::publishEvent(shared_ptr<Even
 };
 
 // TODO: Add a timeout to this method to prevent hanging while waiting for the relay.
-std::future<vector<shared_ptr<Event>>> NostrService::queryRelays(shared_ptr<Filters> filters)
+future<vector<shared_ptr<Event>>> NostrService::queryRelays(shared_ptr<Filters> filters)
 {
-    return std::async(std::launch::async, [this, filters]() -> vector<shared_ptr<Event>>
+    return async(launch::async, [this, filters]() -> vector<shared_ptr<Event>>
     {
         if (filters->limit > 64 || filters->limit < 1)
         {
@@ -267,20 +267,20 @@ std::future<vector<shared_ptr<Event>>> NostrService::queryRelays(shared_ptr<Filt
 
         // Close open subscriptions and disconnect from relays after events are received.
 
-		for (auto& publishFuture : requestFutures)
-		{
-			auto [relay, isEose] = publishFuture.get();
-			if (isEose)
-			{
-				PLOG_INFO << "Received EOSE message from relay " << relay;
-			}
-			else
-			{
-				PLOG_WARNING << "Received CLOSE message from relay " << relay;
-				this->closeRelayConnections({ relay });
-			}
-		}
-		this->closeSubscription(subscriptionId);
+        for (auto& publishFuture : requestFutures)
+        {
+            auto [relay, isEose] = publishFuture.get();
+            if (isEose)
+            {
+                PLOG_INFO << "Received EOSE message from relay " << relay;
+            }
+            else
+            {
+                PLOG_WARNING << "Received CLOSE message from relay " << relay;
+                this->closeRelayConnections({ relay });
+            }
+        }
+        this->closeSubscription(subscriptionId);
 
         return events;
     });

--- a/src/nostr_service.cpp
+++ b/src/nostr_service.cpp
@@ -184,7 +184,7 @@ tuple<vector<string>, vector<string>> NostrService::publishEvent(shared_ptr<Even
 
 // TODO: Make this method return a promise.
 // TODO: Add a timeout to this method to prevent hanging while waiting for the relay.
-vector<shared_ptr<Event>> NostrService::queryRelays(shared_ptr<Filters> filters)
+std::future<vector<shared_ptr<Event>> NostrService::queryRelays(shared_ptr<Filters> filters)
 {
     if (filters->limit > 64 || filters->limit < 1)
     {

--- a/test/nostr_service_test.cpp
+++ b/test/nostr_service_test.cpp
@@ -771,7 +771,9 @@ TEST_F(NostrServiceTest, QueryRelays_ReturnsEvents_UpToEOSE)
         }));
 
     auto filters = make_shared<nostr::Filters>(getKind0And1TestFilters());
-    auto results = nostrService->queryRelays(filters);
+	
+	// await the future and get the results
+    auto results = nostrService->queryRelays(filters).get();
 
     // Check results size to ensure there are no duplicates.
     ASSERT_EQ(results.size(), testEvents.size());

--- a/test/nostr_service_test.cpp
+++ b/test/nostr_service_test.cpp
@@ -772,7 +772,7 @@ TEST_F(NostrServiceTest, QueryRelays_ReturnsEvents_UpToEOSE)
 
     auto filters = make_shared<nostr::Filters>(getKind0And1TestFilters());
 	
-	// await the future and get the results
+    // await the future and get the results
     auto results = nostrService->queryRelays(filters).get();
 
     // Check results size to ensure there are no duplicates.


### PR DESCRIPTION
`queryRelays` called without callbacks returns `std::future`.
 
A future is proposed as an alternative to a promise for the return type as this is most like to be what consumers of the api would expect. An alternative pattern would most likely be to accept a promise as an argument but I am not sure what the utility would be.

The test simply adds `.get()` to the function call. This ensures that a future is indeed returned and that the promise is fulfilled correctly. I am not sure how to test that any waiting actually happens and am just trusting the standard library.