### PR TITLE
refactor: update libs, quick error fixes, rng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ include_directories(${uuid_v4_SOURCE_DIR})
 FetchContent_Declare(
     libnoscrypt
     GIT_REPOSITORY git@github.com:VnUgE/noscrypt.git
-    GIT_TAG v0.1.4
+    GIT_TAG v0.1.5
 )
 FetchContent_MakeAvailable(libnoscrypt)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ include_directories(${uuid_v4_SOURCE_DIR})
 FetchContent_Declare(
     libnoscrypt
     GIT_REPOSITORY git@github.com:VnUgE/noscrypt.git
-    GIT_TAG fb3608b9455b3e0956e401e6254da13cebd71558
+    GIT_TAG v0.1.4
 )
 FetchContent_MakeAvailable(libnoscrypt)
 
@@ -86,7 +86,6 @@ set(HEADERS
     ${INCLUDE_DIR}/nostr.hpp
     ${CLIENT_INCLUDE_DIR}/web_socket_client.hpp
     ${CLIENT_INCLUDE_DIR}/websocketpp_client.hpp
-    ${CRYPTOGRAPHY_INCLUDE_DIR}/noscrypt_cipher.hpp
     ${DATA_INCLUDE_DIR}/data.hpp
     ${SERVICE_INCLUDE_DIR}/nostr_service_base.hpp
     ${SIGNER_INCLUDE_DIR}/signer.hpp
@@ -102,6 +101,7 @@ set(SIGNER_SOURCE_DIR ./src/signer)
 set(SOURCES
     ${CLIENT_SOURCE_DIR}/websocketpp_client.cpp
     ${CRYPTOGRAPHY_SOURCE_DIR}/noscrypt_cipher.cpp
+    ${CRYPTOGRAPHY_SOURCE_DIR}/nostr_secure_rng.cpp
     ${DATA_SOURCE_DIR}/event.cpp
     ${DATA_SOURCE_DIR}/filters.cpp
     ${SERVICE_SOURCE_DIR}/nostr_service_base.cpp

--- a/include/signer/noscrypt_signer.hpp
+++ b/include/signer/noscrypt_signer.hpp
@@ -146,12 +146,6 @@ private:
     #pragma region Cryptography
 
     /**
-     * @brief Reseeds OpenSSL's pseudo-random number generator, using `/dev/random` as the seed, if
-     * possible.
-    */
-    void _reseedRandomNumberGenerator(uint32_t bufferSize = 32);
-
-    /**
      * @brief Encrypts a string according to the standard specified in NIP-04.
      * @param input The string to be encrypted.
      * @return The resulting encrypted string, or an empty string if the input could not be

--- a/include/signer/noscrypt_signer.hpp
+++ b/include/signer/noscrypt_signer.hpp
@@ -176,16 +176,6 @@ private:
     std::string _decryptNip44(const std::string input);
 
     #pragma endregion
-
-    #pragma region Logging
-
-    inline void _logNoscryptInitResult(NCResult initResult) const;
-
-    inline void _logNoscryptSecretValidationResult(NCResult secretValidationResult) const;
-
-    inline void _logNoscryptPubkeyGenerationResult(NCResult pubkeyGenerationResult) const;
-
-    #pragma endregion
 };
 } // namespace signer
 } // namespace nostr

--- a/src/cryptography/noscrypt_cipher.hpp
+++ b/src/cryptography/noscrypt_cipher.hpp
@@ -9,6 +9,19 @@ namespace nostr
 {
 namespace cryptography
 {
+
+enum NoscryptCipherMode : uint32_t
+{
+    CIPHER_MODE_ENCRYPT = NC_UTIL_CIPHER_MODE_ENCRYPT,
+    CIPHER_MODE_DECRYPT = NC_UTIL_CIPHER_MODE_DECRYPT,
+};
+  
+enum NoscryptCipherVersion : uint32_t
+{
+	NIP04 = NC_ENC_VERSION_NIP04,
+	NIP44 = NC_ENC_VERSION_NIP44,
+};
+
 class NoscryptCipherContext
 {
 private:
@@ -16,7 +29,7 @@ private:
 
 public:
 
-    NoscryptCipherContext(uint32_t version, uint32_t mode)
+    NoscryptCipherContext(NoscryptCipherVersion version, NoscryptCipherMode mode)
     {
     /*
     * Create a new cipher context with the specified
@@ -37,8 +50,8 @@ public:
     */
 
     _cipher = NCUtilCipherAlloc(
-        version,
-        mode | NC_UTIL_CIPHER_ZERO_ON_FREE | NC_UTIL_CIPHER_REUSEABLE
+        (uint32_t)version,
+        ((uint32_t)mode) | NC_UTIL_CIPHER_ZERO_ON_FREE | NC_UTIL_CIPHER_REUSEABLE
     );
 
     //TODO, may fail to allocate memory.
@@ -95,6 +108,12 @@ public:
         return (uint32_t)result;
     }
 
+    NoscryptCipherMode mode() const
+    {
+		//Mode bit is lsb so just mask off the rest of the flags and convert back to enum
+		return (NoscryptCipherMode)(flags() & NC_UTIL_CIPHER_MODE);
+    }
+
     NCResult readOutput(std::vector<uint8_t>& output) const
     {
         return NCUtilCipherReadOutput(_cipher, output.data(), (uint32_t)output.size());
@@ -125,7 +144,7 @@ private:
     std::vector<uint8_t> _ivBuffer;
 
 public:
-    NoscryptCipher(uint32_t version, uint32_t mode);
+    NoscryptCipher(NoscryptCipherVersion version, NoscryptCipherMode mode);
 
     /*
      * @brief Performs the cipher operation on the input data. Depending on the mode

--- a/src/cryptography/noscrypt_cipher.hpp
+++ b/src/cryptography/noscrypt_cipher.hpp
@@ -4,6 +4,7 @@
 
 #include <noscrypt.h>
 #include <noscryptutil.h>
+#include "../internal/noscrypt_logger.hpp"
 
 namespace nostr
 {
@@ -31,28 +32,28 @@ public:
 
     NoscryptCipherContext(NoscryptCipherVersion version, NoscryptCipherMode mode)
     {
-    /*
-    * Create a new cipher context with the specified
-    * version and mode that will live for the duration of the
-    * instance.
-    *
-    * The user is expected to use the noscryptutil mode for
-    * setting encryption/decryption modes.
-    *
-    * The cipher will zero out the memory when it is freed.
-    *
-    * For decryption, by default the mac is verified before
-    * decryption occurs.
-    *
-    * NOTE: The ciper is set to reusable mode, so encrypt/decrypt
-    * can be called multiple times although it's not recommended,
-    * its just the more predictable way for users to handle it.
-    */
+        /*
+        * Create a new cipher context with the specified
+        * version and mode that will live for the duration of the
+        * instance.
+        *
+        * The user is expected to use the noscryptutil mode for
+        * setting encryption/decryption modes.
+        *
+        * The cipher will zero out the memory when it is freed.
+        *
+        * For decryption, by default the mac is verified before
+        * decryption occurs.
+        *
+        * NOTE: The ciper is set to reusable mode, so encrypt/decrypt
+        * can be called multiple times although it's not recommended,
+        * its just the more predictable way for users to handle it.
+        */
 
-    _cipher = NCUtilCipherAlloc(
-        (uint32_t)version,
-        ((uint32_t)mode) | NC_UTIL_CIPHER_ZERO_ON_FREE | NC_UTIL_CIPHER_REUSEABLE
-    );
+        _cipher = NCUtilCipherAlloc(
+            (uint32_t)version,
+            ((uint32_t)mode) | NC_UTIL_CIPHER_ZERO_ON_FREE | NC_UTIL_CIPHER_REUSEABLE
+        );
 
     //TODO, may fail to allocate memory.
     }

--- a/src/cryptography/nostr_secure_rng.cpp
+++ b/src/cryptography/nostr_secure_rng.cpp
@@ -1,0 +1,46 @@
+#include <plog/Init.h>
+#include <plog/Log.h>
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/crypto.h>
+
+#include "nostr_secure_rng.hpp"
+
+using namespace std;
+using namespace nostr::cryptography;
+
+void NostrSecureRng::fill(void* buffer, size_t length)
+{
+	if (RAND_bytes((uint8_t*)buffer, length) != 1)
+	{
+		//TODO throw runtime exception
+		PLOG_ERROR << "Failed to generate random bytes";
+	}
+}
+
+inline void NostrSecureRng::fill(vector<uint8_t>& buffer)
+{
+	fill(buffer.data(), buffer.size());
+}
+
+void NostrSecureRng::reseed(uint32_t bufferSize)
+{
+	int rc = RAND_load_file("/dev/random", bufferSize);
+
+	if (rc != bufferSize)
+	{
+		PLOG_WARNING << "Failed to reseed the RNG with /dev/random, falling back to /dev/urandom.";
+		RAND_poll();
+	}
+}
+
+void NostrSecureRng::zero(void* buffer, size_t length)
+{
+	OPENSSL_cleanse(buffer, length);
+}
+
+inline void NostrSecureRng::zero(vector<uint8_t>& buffer)
+{
+	zero(buffer.data(), buffer.size());
+}

--- a/src/cryptography/nostr_secure_rng.hpp
+++ b/src/cryptography/nostr_secure_rng.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+
+namespace nostr
+{
+namespace cryptography
+{
+
+class NostrSecureRng
+{
+private:
+
+public:
+
+    /**
+	* @brief Fills the given buffer with secure random bytes.
+	* @param buffer The buffer to fill with random bytes.
+	* @param length The number of bytes to fill.
+    */
+    static void fill(void* buffer, size_t length);
+
+    /*
+	* @brief Fills the given vector with secure random bytes.
+	* @param buffer The vector to fill with random bytes.
+    */
+    static inline void fill(std::vector<uint8_t>& buffer);
+
+	/*
+	* @brief Reseeds the RNG with random bytes from /dev/random.
+	* @param bufferSize The number of bytes to read from /dev/random.
+	*/
+	static void reseed(uint32_t bufferSize = 32);
+
+	/*
+	* @brief Securley zeroes out the given buffer.
+	* @param buffer A pointer to the buffer to zero out.
+	* @param length The number of bytes to zero out.
+	*/
+	static void zero(void* buffer, size_t length);
+
+	/*
+	* @brief Securley zeroes out the given vector.
+	* @param buffer The vector to zero out.
+	*/
+	static inline void zero(std::vector<uint8_t>& buffer);
+};
+
+} // namespace cryptography
+} // namespace nostr

--- a/src/cryptography/nostr_secure_rng.hpp
+++ b/src/cryptography/nostr_secure_rng.hpp
@@ -26,25 +26,25 @@ public:
     */
     static inline void fill(std::vector<uint8_t>& buffer);
 
-	/*
-	* @brief Reseeds the RNG with random bytes from /dev/random.
-	* @param bufferSize The number of bytes to read from /dev/random.
-	* @remark Falls back to /dev/urandom if /dev/random is not available.
-	*/
-	static void reseed(uint32_t bufferSize = 32);
+    /*
+     * @brief Reseeds the RNG with random bytes from /dev/random.
+     * @param bufferSize The number of bytes to read from /dev/random.
+     * @remark Falls back to /dev/urandom if /dev/random is not available.
+     */
+    static void reseed(uint32_t bufferSize = 32);
 
-	/*
-	* @brief Securley zeroes out the given buffer.
-	* @param buffer A pointer to the buffer to zero out.
-	* @param length The number of bytes to zero out.
-	*/
-	static void zero(void* buffer, size_t length);
+    /*
+     * @brief Securley zeroes out the given buffer.
+     * @param buffer A pointer to the buffer to zero out.
+     * @param length The number of bytes to zero out.
+     */
+    static void zero(void* buffer, size_t length);
 
-	/*
-	* @brief Securley zeroes out the given vector.
-	* @param buffer The vector to zero out.
-	*/
-	static inline void zero(std::vector<uint8_t>& buffer);
+    /*
+     * @brief Securley zeroes out the given vector.
+     * @param buffer The vector to zero out.
+     */
+    static inline void zero(std::vector<uint8_t>& buffer);
 };
 
 } // namespace cryptography

--- a/src/cryptography/nostr_secure_rng.hpp
+++ b/src/cryptography/nostr_secure_rng.hpp
@@ -29,6 +29,7 @@ public:
 	/*
 	* @brief Reseeds the RNG with random bytes from /dev/random.
 	* @param bufferSize The number of bytes to read from /dev/random.
+	* @remark Falls back to /dev/urandom if /dev/random is not available.
 	*/
 	static void reseed(uint32_t bufferSize = 32);
 

--- a/src/internal/noscrypt_logger.hpp
+++ b/src/internal/noscrypt_logger.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <plog/Log.h>
+#include <noscrypt.h>
+
+/*
+* @brief Logs an error message with the function name and line number where the 
+* error occurred. This is useful for debugging and logging errors in the Noscrypt
+* library.
+*/
+#define NC_LOG_ERROR(result) _printNoscryptError(result, __func__, __LINE__)
+
+static inline void _printNoscryptError(NCResult result, const std::string funcName, int lineNum)
+{
+    uint8_t argPosition;
+
+    switch (NCParseErrorCode(result, &argPosition))
+    {
+    case E_NULL_PTR:
+        PLOG_ERROR << "noscrypt - error: A null pointer was passed in " << funcName << "(" << argPosition << ") at line " << lineNum;
+        break;
+
+    case E_INVALID_ARG:
+        PLOG_ERROR << "noscrypt - error: An invalid argument was passed in " << funcName << "(" << argPosition << ") at line " << lineNum;
+        break;
+
+    case E_INVALID_CONTEXT:
+        PLOG_ERROR << "noscrypt - error: An invalid context was passed in " << funcName << "(" << argPosition << ") on line " << lineNum;
+        break;
+
+    case E_ARGUMENT_OUT_OF_RANGE:
+        PLOG_ERROR << "noscrypt - error: An argument was out of range in " << funcName << "(" << argPosition << ") at line " << lineNum;
+        break;
+
+    case E_OPERATION_FAILED:
+        PLOG_ERROR << "noscrypt - error: An operation failed in " << funcName << "(" << argPosition << ") at line " << lineNum;
+        break;
+
+    default:
+        PLOG_ERROR << "noscrypt - error: An unknown error " << result << " occurred in " << funcName << "(" << argPosition << ") at line " << lineNum;
+        break;
+    }
+}

--- a/src/signer/noscrypt_signer.cpp
+++ b/src/signer/noscrypt_signer.cpp
@@ -21,22 +21,16 @@ using namespace nostr::cryptography;
 
 #pragma region Local Statics
 
-static void _ncFreeContext(NCContext* ctx)
-{
-    operator delete(ctx);
-}
-
 static shared_ptr<NCContext> ncAllocContext()
 {
-    /* Allocates a new unmanaged block that will 
-    * be freed manually with the above helper when the smart 
-    * pointer is destroyed
+    /* 
+	* Use the utilties library to allocate a new Noscrypt context. 
+    * Shared pointer will call free when smart pointer is destroyed 
     */
-    void* ctxMemory = operator new(NCGetContextStructSize());
 
     return shared_ptr<NCContext>(
-        static_cast<NCContext*>(ctxMemory), 
-        _ncFreeContext
+        NCUtilContextAlloc(),
+        &NCUtilContextFree
     );
 }
 

--- a/src/signer/noscrypt_signer.cpp
+++ b/src/signer/noscrypt_signer.cpp
@@ -440,7 +440,7 @@ shared_ptr<Event> NoscryptSigner::_wrapSignerMessage(nlohmann::json jrpc)
     // TODO: Handle result codes.
     if (signatureResult != NC_SUCCESS)
     {
-		NC_LOG_ERROR(signatureResult);
+        NC_LOG_ERROR(signatureResult);
         return nullptr;
     }
 


### PR DESCRIPTION
- update noscypt to v0.1.4
- setup proper `NCContext` dynamic memory allocation
- removed cipher header from public api
- moved rng functions to a dedicated rng static class
- added enums for cipher mode/versions
- replaced cast operators with C++ cast expressions where possible (should figure out how to use `static_cast` instead)
- update base64 functions 
- use stack allocated buffers for schnorr signatures and entropy buffers
- unify random functions